### PR TITLE
Use public remote

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "MASPreferences"]
 	path = MASPreferences
-	url = git@github.com:shpakovski/MASPreferences.git
+	url = https://github.com/shpakovski/MASPreferences.git


### PR DESCRIPTION
The current one uses the `git@`remote which requires you to be a collaborator to use.
